### PR TITLE
Clean up code

### DIFF
--- a/example.css
+++ b/example.css
@@ -3,7 +3,7 @@
   color: white;
 }
 
-.UserAvatar--inner {
+.UserAvatar-inner {
   box-sizing: border-box;
   white-space: nowrap;
   overflow: hidden;
@@ -14,6 +14,6 @@
   color: gray;
 }
 
-.UserAvatar--light .UserAvatar--inner {
+.UserAvatar--light .UserAvatar-inner {
   border: 1px solid lightgray;
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const initials = require('initials');
-const addPx = require('add-px');
 const contrast = require('contrast');
 
 // from https://flatuicolors.com/
@@ -41,7 +40,6 @@ class UserAvatar extends React.Component {
     if (!name) throw new Error('UserAvatar requires a name');
 
     const abbr = initials(name);
-    size = addPx(size);
 
     const imageStyle = {
       display: 'block',
@@ -62,7 +60,7 @@ class UserAvatar extends React.Component {
 
     let inner, classes = [className, 'UserAvatar'];
     if (src || srcset) {
-      inner = <img className="UserAvatar--img" style={imageStyle} src={src} srcset={srcset} alt={name} />
+      inner = <img className="UserAvatar-img" style={imageStyle} src={src} srcset={srcset} alt={name} />
     } else {
       let background;
       if (color) {
@@ -84,7 +82,7 @@ class UserAvatar extends React.Component {
 
     return (
       <div aria-label={name} className={classes.join(' ')} style={style}>
-        <div className="UserAvatar--inner" style={innerStyle}>
+        <div className="UserAvatar-inner" style={innerStyle}>
           {inner}
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react-dom": "^0.14.3"
   },
   "dependencies": {
-    "add-px": "^1.0.0",
     "contrast": "^1.0.1",
     "initials": "^2.1.5"
   },


### PR DESCRIPTION
I've taken the time to do a few minor changes.

I don't think you need `add-px` dep, as React adds px by default to width and height so I removed it.

I see you follow a similar convention to suit, and if you do, UserAvatar--inner, means modifier, not subpart. I've modified the class names of subpart and now instead of `UserAvatar--inner` and `UserAvatar--img` we have `UserAvatar-inner` and `UserAvatar-img`.
