### PR TITLE
Props should be camelcase, like srcset

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class UserAvatar extends React.Component {
 
     let inner, classes = [className, 'UserAvatar'];
     if (src || srcset) {
-      inner = <img className="UserAvatar--img" style={imageStyle} src={src} srcset={srcset} alt={name} />
+      inner = <img className="UserAvatar--img" style={imageStyle} src={src} srcSet={srcset} alt={name} />
     } else {
       let background;
       if (color) {


### PR DESCRIPTION
React throws warning if you are using `srcset` instead of their version, which is `srcSet` as it can be seen here: https://facebook.github.io/react/docs/dom-elements.html#all-supported-html-attributes

The following warning is shown:

```
Warning: Unknown DOM property srcset. Did you mean srcSet?
    in img (created by UserAvatar)
    in div (created by UserAvatar)
```

I personally dislike seeing these warnings.

It _should not_ break anything, since React has been using `srcSet` [since 0.10](https://facebook.github.io/react/blog/2014/03/21/react-v0.10.html#new-features)
